### PR TITLE
Create persist module 

### DIFF
--- a/persist/pom.xml
+++ b/persist/pom.xml
@@ -9,16 +9,13 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>api</artifactId>
+  <artifactId>persist</artifactId>
 
   <dependencies>
+    <!-- Database connector -->
     <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-web</artifactId>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
     </dependency>
     <!-- Mockito testing -->
     <dependency>
@@ -31,11 +28,6 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
-    </dependency>
-    <!-- Jackson Unmarshalling -->
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
   <modules>
     <module>api</module>
     <module>service</module>
+    <module>persist</module>
   </modules>
 
   <!--

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -51,6 +51,11 @@
       <artifactId>api</artifactId>
       <version>1.0-SNAPSHOT</version>
     </dependency>
+    <dependency>
+      <groupId>com.codeforcommunity</groupId>
+      <artifactId>persist</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
I ended up adding the persist module because I want to abstract away the database interaction from the processors, especially since we'll be switching out an in-memory one for the real one later on.